### PR TITLE
Add protocol to fix link going to a 404

### DIFF
--- a/about.md
+++ b/about.md
@@ -69,5 +69,5 @@ You can find me online in various places, by various usernames:
 * [Facebook](https://facebook.com/matthewbischoff)
 * [Reddit](http://www.reddit.com/user/matthewbischoff/)
 * [Kickstarter](https://www.kickstarter.com/profile/matthewbischoff)
-* [LinkedIn](www.linkedin.com/in/matthewbischoff/)
+* [LinkedIn](https://www.linkedin.com/in/matthewbischoff/)
 * [Product Hunt](https://www.producthunt.com/@mb)


### PR DESCRIPTION
Previously, clicking on the LinkedIn link led to a 404 page because the link was being treated as a relative URL. After the update, the URL will be treated absolutely.