### PR TITLE
increased minimum size of header to accomidate additional text wrapping that occurs on small mobile devices

### DIFF
--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -57,7 +57,7 @@ header {
 
   @media (max-width: $max-mobile-width) {
     padding: 0px;
-    min-height: 375px;
+    min-height: 385px;
   }
 }
 


### PR DESCRIPTION
This occurs on small mobile devices: iPhone SE (2016) and iPhone 5S

# Before:
![image](https://user-images.githubusercontent.com/19353631/93875183-86853600-fca2-11ea-8154-6cecba78ed86.png)
# After:
![image](https://user-images.githubusercontent.com/19353631/93875193-8b49ea00-fca2-11ea-8013-4eb6287e35da.png)
